### PR TITLE
Add database support

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,2 +1,3 @@
 HOST=localhost
 PORT=8484
+DATABASE_URL=postgres://postgres@localhost:5432/cjms

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 actix-web = "3"
 dotenv = "0.11"
+diesel = { version = "1.4.8", features = ["postgres"] }
 
 [dev-dependencies]
 actix-rt = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 actix-web = "3"
 dotenv = "0.15"
-diesel = { version = "1.4.8", features = ["postgres"] }
+diesel = { version = "1.4.8", features = ["postgres", "r2d2"] }
 
 [dev-dependencies]
 actix-rt = "2"

--- a/README.md
+++ b/README.md
@@ -80,3 +80,13 @@ into main. The supports the following workflow elements:
 PRs should be squash merged into the release branch.
 
 Release branch should be merged with a merge commit into main.
+
+
+# TODO
+
+- Add README docs on how to install `diesel_cli`
+
+`sudo apt install openssl libpq-dev -y`
+`cargo install diesel_cli --no-default-features --features postgres`
+
+Then run `diesel setup`

--- a/diesel.toml
+++ b/diesel.toml
@@ -1,0 +1,5 @@
+# For documentation on how to configure this file,
+# see diesel.rs/guides/configuring-diesel-cli
+
+[print_schema]
+file = "src/schema.rs"

--- a/migrations/00000000000000_diesel_initial_setup/down.sql
+++ b/migrations/00000000000000_diesel_initial_setup/down.sql
@@ -1,0 +1,6 @@
+-- This file was automatically created by Diesel to setup helper functions
+-- and other internal bookkeeping. This file is safe to edit, any future
+-- changes will be added to existing projects as new migrations.
+
+DROP FUNCTION IF EXISTS diesel_manage_updated_at(_tbl regclass);
+DROP FUNCTION IF EXISTS diesel_set_updated_at();

--- a/migrations/00000000000000_diesel_initial_setup/up.sql
+++ b/migrations/00000000000000_diesel_initial_setup/up.sql
@@ -1,0 +1,36 @@
+-- This file was automatically created by Diesel to setup helper functions
+-- and other internal bookkeeping. This file is safe to edit, any future
+-- changes will be added to existing projects as new migrations.
+
+
+
+
+-- Sets up a trigger for the given table to automatically set a column called
+-- `updated_at` whenever the row is modified (unless `updated_at` was included
+-- in the modified columns)
+--
+-- # Example
+--
+-- ```sql
+-- CREATE TABLE users (id SERIAL PRIMARY KEY, updated_at TIMESTAMP NOT NULL DEFAULT NOW());
+--
+-- SELECT diesel_manage_updated_at('users');
+-- ```
+CREATE OR REPLACE FUNCTION diesel_manage_updated_at(_tbl regclass) RETURNS VOID AS $$
+BEGIN
+    EXECUTE format('CREATE TRIGGER set_updated_at BEFORE UPDATE ON %s
+                    FOR EACH ROW EXECUTE PROCEDURE diesel_set_updated_at()', _tbl);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION diesel_set_updated_at() RETURNS trigger AS $$
+BEGIN
+    IF (
+        NEW IS DISTINCT FROM OLD AND
+        NEW.updated_at IS NOT DISTINCT FROM OLD.updated_at
+    ) THEN
+        NEW.updated_at := current_timestamp;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;

--- a/migrations/2022-02-15-210536_create_cj_events/down.sql
+++ b/migrations/2022-02-15-210536_create_cj_events/down.sql
@@ -1,0 +1,2 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE cj_events;

--- a/migrations/2022-02-15-210536_create_cj_events/up.sql
+++ b/migrations/2022-02-15-210536_create_cj_events/up.sql
@@ -1,0 +1,7 @@
+CREATE TABLE cj_events (
+    id SERIAL PRIMARY KEY,  -- TODO this may be better as a UUID
+    flow_id TEXT,  -- TODO confirm type, uniqueness, nullability
+    cj_id TEXT  -- TODO confirm type, uniqueness, nullability
+    -- TODO add created_at
+    -- TODO add updated_at (it appears that there is a diesel pg function for this purpose)
+);

--- a/src/appconfig.rs
+++ b/src/appconfig.rs
@@ -8,5 +8,6 @@ pub fn config_app(cfg: &mut ServiceConfig) {
             .service(resource("").route(get().to(handlers::index)))
             .service(resource("__heartbeat__").route(get().to(handlers::heartbeat)))
             .service(resource("__lbheartbeat__").route(get().to(handlers::heartbeat)))
+            .service(resource("__test_db_insert__").route(get().to(handlers::test_db_insert)))
     );
 }

--- a/src/bin/cjms.rs
+++ b/src/bin/cjms.rs
@@ -1,18 +1,23 @@
-use actix_web::{middleware, App, HttpServer};
+use actix_web::{middleware, web, App, HttpServer};
 use dotenv::dotenv;
 
 use cjms::appconfig::config_app;
+use cjms::db::create_database_pool;
 use cjms::env::get_env;
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     dotenv().ok();
     let env = get_env();
+
+    let db_pool = create_database_pool(&env.database_url);
+
     let addr = format!("{}:{}", env.host, env.port);
     println!("Server running at http://{}", addr);
-    HttpServer::new(|| {
+    HttpServer::new(move || {
         App::new()
             .configure(config_app)
+            .app_data(web::Data::new(db_pool.clone()))
             .wrap(middleware::Logger::default())
     })
     .bind(addr)?

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,0 +1,13 @@
+use diesel::prelude::*;
+use diesel::r2d2::{self, ConnectionManager};
+
+pub type DbPool = r2d2::Pool<ConnectionManager<PgConnection>>;
+pub type DbError = Box<dyn std::error::Error + Send + Sync>;
+
+
+pub fn create_database_pool(database_url: &String) -> DbPool {
+    let connection_manager = ConnectionManager::<PgConnection>::new(database_url);
+    r2d2::Pool::builder()
+        .build(connection_manager)
+        .expect(&format!("Failed to establish database connection to {}", database_url))
+}

--- a/src/env.rs
+++ b/src/env.rs
@@ -1,12 +1,13 @@
 use std::collections::HashMap;
 use std::env;
 
-const REQUIRED_ENV_VARS: [&str; 2] = ["HOST", "PORT"];
+const REQUIRED_ENV_VARS: [&str; 3] = ["HOST", "PORT", "DATABASE_URL"];
 
 #[derive(PartialEq, Eq, Debug)]
 pub struct Env {
     pub host: String,
     pub port: String,
+    pub database_url: String,
 }
 
 pub fn get_env() -> Env {
@@ -15,16 +16,17 @@ pub fn get_env() -> Env {
         match env::var_os(key) {
             Some(val) => {
                 env.insert(
-                    key,  
+                    key,
                     val.into_string().unwrap()
                 );
             },
-            None =>  panic!("Aborting. `{}` is not defined in environment.", key),
+            None => panic!("Aborting. `{}` is not defined in environment.", key),
         }
     }
-    let frozen = Env { 
-        host: env["HOST"].to_string(), 
-        port: env["PORT"].to_string() 
+    let frozen = Env {
+        host: env["HOST"].to_string(),
+        port: env["PORT"].to_string(),
+        database_url: env["DATABASE_URL"].to_string(),
     };
     frozen
 }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,4 +1,8 @@
-use actix_web::{Error, HttpResponse};
+use actix_web::{web, Error, HttpResponse};
+use diesel::prelude::*;
+
+use crate::db::{DbPool, DbError};
+use crate::models;
 
 pub async fn index() -> Result<HttpResponse, Error> {
     Ok(HttpResponse::Ok().body("Hello world!"))
@@ -6,4 +10,33 @@ pub async fn index() -> Result<HttpResponse, Error> {
 
 pub async fn heartbeat() -> Result<HttpResponse, Error> {
     Ok(HttpResponse::Ok().body("OK"))
+}
+
+// TODO this may be better off in a different file
+pub fn insert_new_cj_event(
+    conn: &PgConnection
+) -> Result<models::NewCjEvent, DbError> {
+    use crate::schema::cj_events::dsl::*;
+
+    let new_cj_event = models::NewCjEvent {
+        flow_id: String::from("abc123"),
+        cj_id: String::from("xyz890"),
+    };
+
+    diesel::insert_into(cj_events).values(&new_cj_event).execute(conn)?;
+    Ok(new_cj_event)
+}
+
+pub async fn test_db_insert(
+    pool: web::Data<DbPool>
+) -> Result<HttpResponse, Error> {
+    let _new_cj_event = web::block(move || {
+        let conn = pool.get()?;
+        insert_new_cj_event(&conn)
+    })
+    .await?;
+    // TODO not sure why this doesn't work ...
+    // .map_err(actix_web::error::ErrorInternalServerError)?;
+
+    Ok(HttpResponse::Ok().body("Hello world!"))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,9 @@
+#[macro_use]
+extern crate diesel;
+
 pub mod appconfig;
+pub mod db;
 pub mod handlers;
 pub mod env;
+pub mod models;
+pub mod schema;

--- a/src/models.rs
+++ b/src/models.rs
@@ -1,0 +1,15 @@
+use crate::schema::cj_events;
+
+#[derive(Debug, Clone, Queryable)]
+pub struct CjEvent {
+    pub id: i32,
+    pub flow_id: String,
+    pub cj_id: String,
+}
+
+#[derive(Debug, Clone, Insertable)]
+#[table_name = "cj_events"]
+pub struct NewCjEvent {
+    pub flow_id: String,
+    pub cj_id: String,
+}

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,0 +1,7 @@
+table! {
+    cj_events (id) {
+        id -> Int4,
+        flow_id -> Nullable<Text>,
+        cj_id -> Nullable<Text>,
+    }
+}


### PR DESCRIPTION
Exploratory pull request that adds database support using diesel.

At the moment, this has a stub database table modelled roughly on the endpoint spec'd in #11, and a test endpoint that inserts a record into the table each time it's hit.

The next steps, if we want to use this, would be to 1) remove all the code that is purely for testing purposes (i.e. the database table and the fake endpoint) and 2) finish whatever configuration would be required to make this production-ready and compatible with the Docker image.