### PR TITLE
status_t not being written for subscriptions

### DIFF
--- a/sqlx-data.json
+++ b/sqlx-data.json
@@ -160,6 +160,125 @@
     },
     "query": "SELECT * FROM refunds WHERE refund_id = $1"
   },
+  "1e67d28b9668c91b10756e982dbf6134a1081f269657283eb8daa97a65fa8b62": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "flow_id",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "subscription_id",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "report_timestamp",
+          "ordinal": 3,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "subscription_created",
+          "ordinal": 4,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "fxa_uid",
+          "ordinal": 5,
+          "type_info": "Text"
+        },
+        {
+          "name": "quantity",
+          "ordinal": 6,
+          "type_info": "Int4"
+        },
+        {
+          "name": "plan_id",
+          "ordinal": 7,
+          "type_info": "Text"
+        },
+        {
+          "name": "plan_currency",
+          "ordinal": 8,
+          "type_info": "Text"
+        },
+        {
+          "name": "plan_amount",
+          "ordinal": 9,
+          "type_info": "Int4"
+        },
+        {
+          "name": "country",
+          "ordinal": 10,
+          "type_info": "Text"
+        },
+        {
+          "name": "aic_id",
+          "ordinal": 11,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "aic_expires",
+          "ordinal": 12,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "cj_event_value",
+          "ordinal": 13,
+          "type_info": "Text"
+        },
+        {
+          "name": "status",
+          "ordinal": 14,
+          "type_info": "Text"
+        },
+        {
+          "name": "status_history",
+          "ordinal": 15,
+          "type_info": "Json"
+        },
+        {
+          "name": "status_t",
+          "ordinal": 16,
+          "type_info": "Timestamptz"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true,
+        true
+      ],
+      "parameters": {
+        "Left": [
+          "Text",
+          "Timestamptz",
+          "Json",
+          "Uuid"
+        ]
+      }
+    },
+    "query": "UPDATE subscriptions\n            SET\n                status = $1,\n                status_t = $2,\n                status_history = $3\n            WHERE id = $4\n\t\t\tRETURNING *"
+  },
   "3284a809ba6e9cee6247b55669639a5af602449c4370f659bdec3baecef05ba9": {
     "describe": {
       "columns": [
@@ -1060,7 +1179,89 @@
     },
     "query": "SELECT * FROM subscriptions WHERE id = $1"
   },
-  "b8681a793dd9645e4e5711286cfc27a569af13ea2597f58cd982ef04a318991a": {
+  "b886f7e80acc8ba7a36a1ffebfb05cc14d321348a150ce494a7c3007bb6993d2": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Uuid"
+        },
+        {
+          "name": "refund_id",
+          "ordinal": 1,
+          "type_info": "Text"
+        },
+        {
+          "name": "subscription_id",
+          "ordinal": 2,
+          "type_info": "Text"
+        },
+        {
+          "name": "refund_created",
+          "ordinal": 3,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "refund_amount",
+          "ordinal": 4,
+          "type_info": "Int4"
+        },
+        {
+          "name": "refund_status",
+          "ordinal": 5,
+          "type_info": "Text"
+        },
+        {
+          "name": "refund_reason",
+          "ordinal": 6,
+          "type_info": "Text"
+        },
+        {
+          "name": "status",
+          "ordinal": 7,
+          "type_info": "Text"
+        },
+        {
+          "name": "status_t",
+          "ordinal": 8,
+          "type_info": "Timestamptz"
+        },
+        {
+          "name": "status_history",
+          "ordinal": 9,
+          "type_info": "Json"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        false,
+        false,
+        false,
+        true,
+        true,
+        true,
+        true,
+        true
+      ],
+      "parameters": {
+        "Left": [
+          "Text",
+          "Timestamptz",
+          "Int4",
+          "Text",
+          "Text",
+          "Text",
+          "Timestamptz",
+          "Json",
+          "Text"
+        ]
+      }
+    },
+    "query": "UPDATE refunds\n            SET\n                subscription_id = $1,\n                refund_created = $2,\n                refund_amount = $3,\n                refund_status = $4,\n                refund_reason = $5,\n                status = $6,\n                status_t = $7,\n                status_history = $8\n            WHERE refund_id = $9\n\t\t\tRETURNING *"
+  },
+  "bc7d831af76ef8a775ee9cfed2f6ad624225dc969769da369fb88b9af027ee7e": {
     "describe": {
       "columns": [
         {
@@ -1170,95 +1371,27 @@
       ],
       "parameters": {
         "Left": [
+          "Uuid",
           "Text",
-          "Json",
-          "Uuid"
-        ]
-      }
-    },
-    "query": "UPDATE subscriptions\n            SET\n                status = $1,\n                status_history = $2\n            WHERE id = $3\n\t\t\tRETURNING *"
-  },
-  "b886f7e80acc8ba7a36a1ffebfb05cc14d321348a150ce494a7c3007bb6993d2": {
-    "describe": {
-      "columns": [
-        {
-          "name": "id",
-          "ordinal": 0,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "refund_id",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "subscription_id",
-          "ordinal": 2,
-          "type_info": "Text"
-        },
-        {
-          "name": "refund_created",
-          "ordinal": 3,
-          "type_info": "Timestamptz"
-        },
-        {
-          "name": "refund_amount",
-          "ordinal": 4,
-          "type_info": "Int4"
-        },
-        {
-          "name": "refund_status",
-          "ordinal": 5,
-          "type_info": "Text"
-        },
-        {
-          "name": "refund_reason",
-          "ordinal": 6,
-          "type_info": "Text"
-        },
-        {
-          "name": "status",
-          "ordinal": 7,
-          "type_info": "Text"
-        },
-        {
-          "name": "status_t",
-          "ordinal": 8,
-          "type_info": "Timestamptz"
-        },
-        {
-          "name": "status_history",
-          "ordinal": 9,
-          "type_info": "Json"
-        }
-      ],
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false,
-        true,
-        true,
-        true,
-        true,
-        true
-      ],
-      "parameters": {
-        "Left": [
           "Text",
           "Timestamptz",
+          "Timestamptz",
+          "Text",
           "Int4",
           "Text",
           "Text",
+          "Int4",
+          "Text",
+          "Uuid",
+          "Timestamptz",
+          "Text",
           "Text",
           "Timestamptz",
-          "Json",
-          "Text"
+          "Json"
         ]
       }
     },
-    "query": "UPDATE refunds\n            SET\n                subscription_id = $1,\n                refund_created = $2,\n                refund_amount = $3,\n                refund_status = $4,\n                refund_reason = $5,\n                status = $6,\n                status_t = $7,\n                status_history = $8\n            WHERE refund_id = $9\n\t\t\tRETURNING *"
+    "query": "INSERT INTO subscriptions (\n                id,\n                flow_id,\n                subscription_id,\n                report_timestamp,\n                subscription_created,\n                fxa_uid,\n                quantity,\n                plan_id,\n                plan_currency,\n                plan_amount,\n                country,\n                aic_id,\n                aic_expires,\n                cj_event_value,\n                status,\n                status_t,\n                status_history\n             )\n\t\t\tVALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)\n\t\t\tRETURNING *"
   },
   "c705eede93655cf085d9d78d82287fb39cbffc54ed579db822a5d45c6a473e20": {
     "describe": {
@@ -1351,136 +1484,5 @@
       }
     },
     "query": "SELECT * FROM aic WHERE id = $1"
-  },
-  "d943053e456cedfc0f07faab2d1b390655ccf91c4ba20ff869c5e00ac17e615d": {
-    "describe": {
-      "columns": [
-        {
-          "name": "id",
-          "ordinal": 0,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "flow_id",
-          "ordinal": 1,
-          "type_info": "Text"
-        },
-        {
-          "name": "subscription_id",
-          "ordinal": 2,
-          "type_info": "Text"
-        },
-        {
-          "name": "report_timestamp",
-          "ordinal": 3,
-          "type_info": "Timestamptz"
-        },
-        {
-          "name": "subscription_created",
-          "ordinal": 4,
-          "type_info": "Timestamptz"
-        },
-        {
-          "name": "fxa_uid",
-          "ordinal": 5,
-          "type_info": "Text"
-        },
-        {
-          "name": "quantity",
-          "ordinal": 6,
-          "type_info": "Int4"
-        },
-        {
-          "name": "plan_id",
-          "ordinal": 7,
-          "type_info": "Text"
-        },
-        {
-          "name": "plan_currency",
-          "ordinal": 8,
-          "type_info": "Text"
-        },
-        {
-          "name": "plan_amount",
-          "ordinal": 9,
-          "type_info": "Int4"
-        },
-        {
-          "name": "country",
-          "ordinal": 10,
-          "type_info": "Text"
-        },
-        {
-          "name": "aic_id",
-          "ordinal": 11,
-          "type_info": "Uuid"
-        },
-        {
-          "name": "aic_expires",
-          "ordinal": 12,
-          "type_info": "Timestamptz"
-        },
-        {
-          "name": "cj_event_value",
-          "ordinal": 13,
-          "type_info": "Text"
-        },
-        {
-          "name": "status",
-          "ordinal": 14,
-          "type_info": "Text"
-        },
-        {
-          "name": "status_history",
-          "ordinal": 15,
-          "type_info": "Json"
-        },
-        {
-          "name": "status_t",
-          "ordinal": 16,
-          "type_info": "Timestamptz"
-        }
-      ],
-      "nullable": [
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        false,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true,
-        true
-      ],
-      "parameters": {
-        "Left": [
-          "Uuid",
-          "Text",
-          "Text",
-          "Timestamptz",
-          "Timestamptz",
-          "Text",
-          "Int4",
-          "Text",
-          "Text",
-          "Int4",
-          "Text",
-          "Uuid",
-          "Timestamptz",
-          "Text",
-          "Text",
-          "Json"
-        ]
-      }
-    },
-    "query": "INSERT INTO subscriptions (\n                id,\n                flow_id,\n                subscription_id,\n                report_timestamp,\n                subscription_created,\n                fxa_uid,\n                quantity,\n                plan_id,\n                plan_currency,\n                plan_amount,\n                country,\n                aic_id,\n                aic_expires,\n                cj_event_value,\n                status,\n                status_history\n             )\n\t\t\tVALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)\n\t\t\tRETURNING *"
   }
 }

--- a/src/lib/models/subscriptions.rs
+++ b/src/lib/models/subscriptions.rs
@@ -73,7 +73,14 @@ impl PartialEq for Subscription {
             },
             None => other.aic_expires.is_none(),
         };
-        aic_expires_match && simple_match
+        let status_t_match = match self.status_t {
+            Some(self_v) => match other.status_t {
+                Some(other_v) => self_v.unix_timestamp() == other_v.unix_timestamp(),
+                None => false,
+            },
+            None => other.status_t.is_none(),
+        };
+        status_t_match && aic_expires_match && simple_match
     }
 }
 impl Eq for Subscription {}

--- a/src/lib/models/subscriptions.rs
+++ b/src/lib/models/subscriptions.rs
@@ -161,9 +161,10 @@ impl SubscriptionModel<'_> {
                 aic_expires,
                 cj_event_value,
                 status,
+                status_t,
                 status_history
              )
-			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
 			RETURNING *",
             sub.id,
             sub.flow_id,
@@ -180,6 +181,7 @@ impl SubscriptionModel<'_> {
             sub.aic_expires,
             sub.cj_event_value,
             sub.status,
+            sub.status_t,
             sub.status_history,
         )
         .fetch_one(self.db_pool)
@@ -246,10 +248,12 @@ impl SubscriptionModel<'_> {
             r#"UPDATE subscriptions
             SET
                 status = $1,
-                status_history = $2
-            WHERE id = $3
+                status_t = $2,
+                status_history = $3
+            WHERE id = $4
 			RETURNING *"#,
             sub.status,
+            sub.status_t,
             sub.status_history,
             id,
         )

--- a/tests/integration/models/refunds.rs
+++ b/tests/integration/models/refunds.rs
@@ -84,7 +84,10 @@ async fn test_refund_model_update_refund_updates_the_status_to_not_reported() {
         .await
         .expect("Could not fetch from DB.");
     assert_eq!(result.get_status().unwrap(), Status::NotReported);
-    assert_eq!(result.get_status_t().unwrap().unix_timestamp(), now.unix_timestamp());
+    assert_eq!(
+        result.get_status_t().unwrap().unix_timestamp(),
+        now.unix_timestamp()
+    );
     assert_eq!(
         result.get_status_history().unwrap().entries[1]
             .t

--- a/tests/integration/models/refunds.rs
+++ b/tests/integration/models/refunds.rs
@@ -74,6 +74,7 @@ async fn test_refund_model_update_refund_updates_the_status_to_not_reported() {
     // This has no effect. It helps us verify that the update_refund function is setting the latest
     // status to NotReported.
     r_update.update_status(Status::WillNotReport);
+    let now = OffsetDateTime::now_utc();
     model
         .update_refund(&mut r_update)
         .await
@@ -83,10 +84,11 @@ async fn test_refund_model_update_refund_updates_the_status_to_not_reported() {
         .await
         .expect("Could not fetch from DB.");
     assert_eq!(result.get_status().unwrap(), Status::NotReported);
+    assert_eq!(result.get_status_t().unwrap().unix_timestamp(), now.unix_timestamp());
     assert_eq!(
         result.get_status_history().unwrap().entries[1]
             .t
             .unix_timestamp(),
-        OffsetDateTime::now_utc().unix_timestamp()
+        now.unix_timestamp()
     );
 }


### PR DESCRIPTION
Fixes PSP-355

There is still an issue where the history is saved in a not-very-human-readable list format. However until we can upgrade to time 0.3 (currently held back because of sqlx, there's no prettier easy alternative for this).