### PR TITLE
Fix flaky version test

### DIFF
--- a/src/lib/version.rs
+++ b/src/lib/version.rs
@@ -49,7 +49,7 @@ mod test_version {
     #[serial]
     #[should_panic(expected = "Couldn't read version file.")]
     async fn read_version_fails_if_no_file() {
-        fs::remove_file(VERSION_FILE_TEST).unwrap();
+        fs::remove_file(VERSION_FILE_TEST).ok();
         read_version(VERSION_FILE_TEST);
     }
 


### PR DESCRIPTION
Stop a test from panicking if it tries to delete a test file that doesn't already exist.