### PR TITLE
Improvements to telemetry infrastructure

### DIFF
--- a/src/bin/batch_refunds.rs
+++ b/src/bin/batch_refunds.rs
@@ -9,8 +9,8 @@ use lib::{
 async fn main() -> std::io::Result<()> {
     let settings = get_settings();
 
-    init_tracing("cjms-batch-refunds", &settings.log_level, std::io::stdout);
     let _guard = init_sentry(&settings);
+    init_tracing("cjms-batch-refunds", &settings.log_level, std::io::stdout);
 
     let db = connect_to_database_and_migrate(&settings.database_url).await;
     // TODO - LOGGING - This is a process we'll want to log and time (if possible)

--- a/src/bin/check_refunds.rs
+++ b/src/bin/check_refunds.rs
@@ -10,8 +10,8 @@ use lib::{
 async fn main() -> std::io::Result<()> {
     let settings = get_settings();
 
-    init_tracing("cjms-check-refunds", &settings.log_level, std::io::stdout);
     let _guard = init_sentry(&settings);
+    init_tracing("cjms-check-refunds", &settings.log_level, std::io::stdout);
 
     let bq = get_bqclient(&settings).await;
     let db = connect_to_database_and_migrate(&settings.database_url).await;

--- a/src/bin/check_subscriptions.rs
+++ b/src/bin/check_subscriptions.rs
@@ -10,12 +10,12 @@ use lib::{
 async fn main() -> std::io::Result<()> {
     let settings = get_settings();
 
+    let _guard = init_sentry(&settings);
     init_tracing(
         "cjms-check-subscriptions",
         &settings.log_level,
         std::io::stdout,
     );
-    let _guard = init_sentry(&settings);
 
     let bq = get_bqclient(&settings).await;
     let db = connect_to_database_and_migrate(&settings.database_url).await;

--- a/src/bin/cleanup.rs
+++ b/src/bin/cleanup.rs
@@ -1,11 +1,17 @@
 use lib::{
-    appconfig::connect_to_database_and_migrate, jobs::cleanup::archive_expired_aics,
+    appconfig::connect_to_database_and_migrate,
+    jobs::cleanup::archive_expired_aics,
     settings::get_settings,
+    telemetry::{init_sentry, init_tracing},
 };
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     let settings = get_settings();
+
+    let _guard = init_sentry(&settings);
+    init_tracing("cjms-cleanup", &settings.log_level, std::io::stdout);
+
     let db = connect_to_database_and_migrate(&settings.database_url).await;
     // TODO - LOGGING - This is a process we'll want to log and time (if possible)
     println!("Starting cleanup");

--- a/src/bin/report_subscriptions.rs
+++ b/src/bin/report_subscriptions.rs
@@ -10,12 +10,12 @@ use lib::{
 async fn main() -> std::io::Result<()> {
     let settings = get_settings();
 
+    let _guard = init_sentry(&settings);
     init_tracing(
         "cjms-report-subscriptions",
         &settings.log_level,
         std::io::stdout,
     );
-    let _guard = init_sentry(&settings);
 
     let db = connect_to_database_and_migrate(&settings.database_url).await;
     let cj_client = CJS2SClient::new(&settings, None);

--- a/src/bin/web.rs
+++ b/src/bin/web.rs
@@ -10,8 +10,8 @@ use std::net::TcpListener;
 async fn main() -> std::io::Result<()> {
     let settings = get_settings();
 
-    init_tracing("cjms-web", &settings.log_level, std::io::stdout);
     let _guard = init_sentry(&settings);
+    init_tracing("cjms-web", &settings.log_level, std::io::stdout);
 
     let statsd_client = create_statsd_client(&settings);
     // TODO what to do with the error?

--- a/src/lib/appconfig.rs
+++ b/src/lib/appconfig.rs
@@ -55,10 +55,6 @@ pub fn run_server(
             .service(
                 resource("/__error_panic__").route(get().to(controllers::custodial::error_panic)),
             )
-            .service(
-                resource("/__error_capture__")
-                    .route(get().to(controllers::custodial::error_capture)),
-            )
             // AIC
             .service(resource("/aic").route(post().to(controllers::aic::create)))
             .service(resource("/aic/{aic_id}").route(put().to(controllers::aic::update)))

--- a/src/lib/controllers/custodial.rs
+++ b/src/lib/controllers/custodial.rs
@@ -1,4 +1,7 @@
-use crate::version::{read_version, VERSION_FILE};
+use crate::{
+    telemetry::{error, info, TraceType},
+    version::{read_version, VERSION_FILE},
+};
 use actix_web::{Error, HttpResponse};
 
 /*
@@ -9,24 +12,22 @@ use actix_web::{Error, HttpResponse};
 
 #[tracing::instrument(name = "request-index")]
 pub async fn index() -> Result<HttpResponse, Error> {
-    tracing::info!(r#type = "request-index-success");
+    info(TraceType::RequestIndexSuccess, "");
     Ok(HttpResponse::Ok().body("Hello world!"))
 }
 
 pub async fn error_log() -> Result<HttpResponse, Error> {
-    tracing::error!(r#type = "request-error-log-test", "Test error log report");
+    let err = "NaN".parse::<usize>().unwrap_err();
+    error(
+        TraceType::RequestErrorLogTest,
+        "Test error log report",
+        Some(Box::new(err)),
+    );
     Ok(HttpResponse::Ok().body("Error log test"))
 }
 
 pub async fn error_panic() -> Result<HttpResponse, Error> {
     panic!("This is fine. :fire:");
-}
-
-pub async fn error_capture() -> Result<HttpResponse, Error> {
-    let err = "NaN".parse::<usize>().unwrap_err();
-    sentry::capture_error(&err);
-
-    Ok(HttpResponse::Ok().body("Error capture test"))
 }
 
 pub async fn heartbeat() -> Result<HttpResponse, Error> {

--- a/src/lib/models/aic.rs
+++ b/src/lib/models/aic.rs
@@ -2,7 +2,10 @@ use sqlx::{query, query_as, Error, PgPool};
 use time::{Duration, OffsetDateTime};
 use uuid::Uuid;
 
-use crate::settings::Settings;
+use crate::{
+    settings::Settings,
+    telemetry::{error, TraceType},
+};
 
 #[derive(Debug)]
 pub struct AIC {
@@ -69,10 +72,10 @@ impl AICModel<'_> {
         .fetch_one(self.db_pool)
         .await
         .map_err(|e| {
-            tracing::error!(
-                r#type = "aic-record-create-failed",
-                "Failed to execute query: {:?}",
-                e
+            error(
+                TraceType::AicRecordCreateFailed,
+                &format!("Failed to execute query: {:?}", e),
+                None,
             );
             e
         })

--- a/src/lib/telemetry.rs
+++ b/src/lib/telemetry.rs
@@ -1,4 +1,4 @@
-use cadence::{StatsdClient, UdpMetricSink};
+&&use cadence::{StatsdClient, UdpMetricSink};
 use sentry::ClientInitGuard;
 use sentry_tracing::EventFilter;
 use std::borrow::Cow;
@@ -11,6 +11,20 @@ use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Registry};
 
 use crate::settings::Settings;
 use crate::version::{read_version, VERSION_FILE};
+
+pub enum TraceType {
+    AicRecordCreate,
+    AicRecordCreateFailed,
+}
+
+impl TraceType {
+    fn as_str(&self) -> &'static str {
+        match self {
+            TraceType::AicRecordCreate => "aic-record-create",
+            TraceType::AicRecordCreateFailed => "aic-record-create-failed",
+        }
+    }
+}
 
 /// Creates a tracing subscriber and sets it as the global default.
 pub fn init_tracing<Sink>(service_name: &str, log_level: &str, sink: Sink)
@@ -46,13 +60,15 @@ pub fn init_sentry(settings: &Settings) -> ClientInitGuard {
         settings.sentry_dsn.clone(),
         sentry::ClientOptions {
             environment: Some(Cow::from(settings.environment.clone())),
+            // Suppress breadcrumbs.
+            max_breadcrumbs: 0,
             release: Some(Cow::from(version_data.version)),
-            /// `sample_rate` defines the sample rate of error events (i.e. panics and error
-            /// log messages). Should always be 1.0.
+            // `sample_rate` defines the sample rate of error events (i.e. panics and error
+            // log messages). Should always be 1.0.
             sample_rate: 1.0,
-            /// `traces_sample_rate` defines the sample rate of "transactional"
-            /// events that are used for performance insights. We don't want any
-            /// of this, so we set to zero.
+            // `traces_sample_rate` defines the sample rate of "transactional"
+            // events that are used for performance insights. We don't want any
+            // of this, so we set to zero.
             traces_sample_rate: 0.0,
             ..Default::default()
         },
@@ -69,4 +85,28 @@ pub fn create_statsd_client(settings: &Settings) -> StatsdClient {
     let sink = UdpMetricSink::from(host, socket).unwrap();
 
     StatsdClient::from_sink("cjms", sink)
+}
+
+pub fn trace(trace_type: TraceType, message: &str) {
+    tracing::trace!(r#type = trace_type.to_string(), message);
+}
+
+pub fn debug(trace_type: TraceType, message: &str) {
+    tracing::debug!(r#type = trace_type.to_string(), message);
+}
+
+pub fn info(trace_type: TraceType, message: &str) {
+    tracing::info!(r#type = trace_type.to_string(), message);
+}
+
+pub fn warn(trace_type: TraceType, message: &str) {
+    tracing::warn!(r#type = trace_type.to_string(), message);
+}
+
+pub fn error(trace_type: TraceType, message: &str, error: Option<Box<dyn std::error::Error>>) {
+    let message = match error {
+        Some(err) => format!("Message: '{}'. Original error: {}", &message, err),
+        None => message,
+    };
+    tracing::error!(r#type = trace_type.to_string(), message);
 }

--- a/src/lib/telemetry.rs
+++ b/src/lib/telemetry.rs
@@ -2,9 +2,8 @@ use cadence::{StatsdClient, UdpMetricSink};
 use sentry::ClientInitGuard;
 use sentry_tracing::EventFilter;
 use std::borrow::Cow;
-use std::fmt;
 use std::net::UdpSocket;
-use strum_macros::{Display as EnumToString};
+use strum_macros::Display as EnumToString;
 use tracing::subscriber::set_global_default;
 use tracing_actix_web_mozlog::{JsonStorageLayer, MozLogFormatLayer};
 use tracing_log::LogTracer;
@@ -15,9 +14,12 @@ use crate::settings::Settings;
 use crate::version::{read_version, VERSION_FILE};
 
 #[derive(Debug, EnumToString)]
+#[strum(serialize_all = "kebab_case")]
 pub enum TraceType {
     AicRecordCreate,
     AicRecordCreateFailed,
+    RequestErrorLogTest,
+    RequestIndexSuccess,
 }
 
 /// Creates a tracing subscriber and sets it as the global default.

--- a/src/lib/telemetry.rs
+++ b/src/lib/telemetry.rs
@@ -4,6 +4,7 @@ use sentry_tracing::EventFilter;
 use std::borrow::Cow;
 use std::fmt;
 use std::net::UdpSocket;
+use strum_macros::{Display as EnumToString};
 use tracing::subscriber::set_global_default;
 use tracing_actix_web_mozlog::{JsonStorageLayer, MozLogFormatLayer};
 use tracing_log::LogTracer;
@@ -13,17 +14,10 @@ use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Registry};
 use crate::settings::Settings;
 use crate::version::{read_version, VERSION_FILE};
 
-#[derive(Debug)]
+#[derive(Debug, EnumToString)]
 pub enum TraceType {
     AicRecordCreate,
     AicRecordCreateFailed,
-}
-
-impl fmt::Display for TraceType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        // TODO convert from camel case to snake case
-        write!(f, "{:?}", self)
-    }
 }
 
 /// Creates a tracing subscriber and sets it as the global default.
@@ -87,20 +81,8 @@ pub fn create_statsd_client(settings: &Settings) -> StatsdClient {
     StatsdClient::from_sink("cjms", sink)
 }
 
-pub fn trace(trace_type: TraceType, message: &str) {
-    tracing::trace!(r#type = trace_type.to_string().as_str(), message);
-}
-
-pub fn debug(trace_type: TraceType, message: &str) {
-    tracing::debug!(r#type = trace_type.to_string().as_str(), message);
-}
-
 pub fn info(trace_type: TraceType, message: &str) {
     tracing::info!(r#type = trace_type.to_string().as_str(), message);
-}
-
-pub fn warn(trace_type: TraceType, message: &str) {
-    tracing::warn!(r#type = trace_type.to_string().as_str(), message);
 }
 
 pub fn error(trace_type: TraceType, message: &str, error: Option<Box<dyn std::error::Error>>) {


### PR DESCRIPTION
- Prevent Sentry from receiving log information below error. This will suppress all performance level info in Sentry (we will use statsd for this).
- Ensure that Sentry is the first thing instantiated at app startup.
- Create a set of wrapper functions that can be used to instrument the application and send calls to logs and statsd at once. (Only log calls have been implemented here, this is for future extension.)
- Create an enum that registers log types to prevent duplication.