### PR TITLE
Logging and metrics everywhere

### DIFF
--- a/src/bin/batch_refunds.rs
+++ b/src/bin/batch_refunds.rs
@@ -1,8 +1,8 @@
-use lib::{appconfig::CJ, jobs::batch_refunds::batch_refunds_by_day, telemetry::TraceType};
+use lib::{appconfig::CJ, jobs::batch_refunds::batch_refunds_by_day, telemetry::LogKey};
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    let cj = CJ::new(TraceType::BatchRefunds).await;
+    let cj = CJ::new(LogKey::BatchRefunds).await;
     batch_refunds_by_day(&cj.db_pool, &cj.statsd).await;
     cj.shutdown().await
 }

--- a/src/bin/check_refunds.rs
+++ b/src/bin/check_refunds.rs
@@ -1,8 +1,8 @@
-use lib::{appconfig::CJ, jobs::check_refunds::fetch_and_process_refunds, telemetry::TraceType};
+use lib::{appconfig::CJ, jobs::check_refunds::fetch_and_process_refunds, telemetry::LogKey};
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    let cj = CJ::new(TraceType::CheckRefunds).await;
+    let cj = CJ::new(LogKey::CheckRefunds).await;
     fetch_and_process_refunds(&cj.bq_client, &cj.db_pool, &cj.statsd).await;
     cj.shutdown().await
 }

--- a/src/bin/check_subscriptions.rs
+++ b/src/bin/check_subscriptions.rs
@@ -1,11 +1,11 @@
 use lib::{
     appconfig::CJ, jobs::check_subscriptions::fetch_and_process_new_subscriptions,
-    telemetry::TraceType,
+    telemetry::LogKey,
 };
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    let cj = CJ::new(TraceType::CheckSubscriptions).await;
+    let cj = CJ::new(LogKey::CheckSubscriptions).await;
     fetch_and_process_new_subscriptions(&cj.bq_client, &cj.db_pool, &cj.statsd).await;
     cj.shutdown().await
 }

--- a/src/bin/cleanup.rs
+++ b/src/bin/cleanup.rs
@@ -3,6 +3,6 @@ use lib::{appconfig::CJ, jobs::cleanup::archive_expired_aics, telemetry::LogKey}
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     let cj = CJ::new(LogKey::Cleanup).await;
-    archive_expired_aics(&cj.db_pool).await;
+    archive_expired_aics(&cj.db_pool, &cj.statsd).await;
     cj.shutdown().await
 }

--- a/src/bin/cleanup.rs
+++ b/src/bin/cleanup.rs
@@ -1,8 +1,8 @@
-use lib::{appconfig::CJ, jobs::cleanup::archive_expired_aics, telemetry::TraceType};
+use lib::{appconfig::CJ, jobs::cleanup::archive_expired_aics, telemetry::LogKey};
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    let cj = CJ::new(TraceType::Cleanup).await;
+    let cj = CJ::new(LogKey::Cleanup).await;
     archive_expired_aics(&cj.db_pool).await;
     cj.shutdown().await
 }

--- a/src/bin/report_subscriptions.rs
+++ b/src/bin/report_subscriptions.rs
@@ -1,10 +1,10 @@
 use lib::{
-    appconfig::CJ, jobs::report_subscriptions::report_subscriptions_to_cj, telemetry::TraceType,
+    appconfig::CJ, jobs::report_subscriptions::report_subscriptions_to_cj, telemetry::LogKey,
 };
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    let cj = CJ::new(TraceType::ReportSubscriptions).await;
+    let cj = CJ::new(LogKey::ReportSubscriptions).await;
     report_subscriptions_to_cj(&cj.db_pool, &cj.cj_client, &cj.statsd).await;
     cj.shutdown().await
 }

--- a/src/bin/web.rs
+++ b/src/bin/web.rs
@@ -1,6 +1,7 @@
 use lib::{
     appconfig::{run_server, CJ},
-    telemetry::{info, TraceType},
+    info,
+    telemetry::TraceType,
 };
 use std::net::TcpListener;
 
@@ -8,9 +9,10 @@ use std::net::TcpListener;
 async fn main() -> std::io::Result<()> {
     let cj = CJ::new(TraceType::WebApp).await;
     let addr = cj.settings.server_address();
-    info(
-        &TraceType::WebApp,
-        &format!("Server running at http://{}", addr),
+    info!(
+        TraceType::WebApp,
+        addr = format!("http://{}", addr).as_str(),
+        "Server running"
     );
     run_server(
         cj.settings.clone(),

--- a/src/bin/web.rs
+++ b/src/bin/web.rs
@@ -1,16 +1,16 @@
 use lib::{
     appconfig::{run_server, CJ},
     info,
-    telemetry::TraceType,
+    telemetry::LogKey,
 };
 use std::net::TcpListener;
 
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    let cj = CJ::new(TraceType::WebApp).await;
+    let cj = CJ::new(LogKey::WebApp).await;
     let addr = cj.settings.server_address();
     info!(
-        TraceType::WebApp,
+        LogKey::WebApp,
         addr = format!("http://{}", addr).as_str(),
         "Server running"
     );

--- a/src/lib/appconfig.rs
+++ b/src/lib/appconfig.rs
@@ -19,12 +19,12 @@ use crate::{
     cj::client::CJS2SClient,
     controllers, info,
     settings::{get_settings, Settings},
-    telemetry::{init_sentry, init_tracing, StatsD, TraceType},
+    telemetry::{init_sentry, init_tracing, LogKey, StatsD},
 };
 
 pub struct CJ {
     _guard: ClientInitGuard,
-    name: TraceType,
+    name: LogKey,
     start: OffsetDateTime,
     pub bq_client: BQClient,
     pub cj_client: CJS2SClient,
@@ -34,11 +34,11 @@ pub struct CJ {
 }
 
 impl CJ {
-    pub async fn new(name: TraceType) -> Self {
+    pub async fn new(name: LogKey) -> Self {
         let start = OffsetDateTime::now_utc();
         let settings = get_settings();
         let _guard = init_sentry(&settings);
-        if name != TraceType::Test {
+        if name != LogKey::Test {
             init_tracing(&name.to_string(), &settings.log_level, std::io::stdout);
         }
         let db_pool = connect_to_database_and_migrate(&settings.database_url).await;

--- a/src/lib/bigquery/model.rs
+++ b/src/lib/bigquery/model.rs
@@ -312,7 +312,7 @@ impl ResultSet {
     }
 
     pub fn report_stats(&self, statsd: &StatsD, key: &LogKey) {
-        statsd.gauge(key, Some("n-from-bq"), self.row_count());
+        statsd.gauge(&key.add_suffix("n-from-bq"), self.row_count());
         let total_rows = self
             .query_response
             .total_rows
@@ -320,7 +320,7 @@ impl ResultSet {
             .unwrap_or_else(|| "-1".to_string());
         match total_rows.parse::<usize>() {
             Ok(n) => {
-                statsd.gauge(key, Some("total-n-from-bq"), n);
+                statsd.gauge(&key.add_suffix("total-n-from-bq"), n);
             }
             Err(e) => error!(LogKey::BigQuery, error = e, "Could not get total rows",),
         };
@@ -331,7 +331,7 @@ impl ResultSet {
             .unwrap_or_else(|| "-1".to_string());
         match bytes_processed.parse::<usize>() {
             Ok(n) => {
-                statsd.gauge(key, Some("bytes-from-bq"), n);
+                statsd.gauge(&key.add_suffix("bytes-from-bq"), n);
             }
             Err(e) => error!(
                 LogKey::BigQuery,

--- a/src/lib/bigquery/model.rs
+++ b/src/lib/bigquery/model.rs
@@ -33,7 +33,7 @@ use time::OffsetDateTime;
 
 use crate::{
     error,
-    telemetry::{StatsD, TraceType},
+    telemetry::{LogKey, StatsD},
 };
 
 #[derive(Error, Debug)]
@@ -311,7 +311,7 @@ impl ResultSet {
         self.row_count as usize
     }
 
-    pub fn report_stats(&self, statsd: &StatsD, key: &TraceType) {
+    pub fn report_stats(&self, statsd: &StatsD, key: &LogKey) {
         statsd.gauge(key, Some("n-from-bq"), self.row_count());
         let total_rows = self
             .query_response
@@ -322,7 +322,7 @@ impl ResultSet {
             Ok(n) => {
                 statsd.gauge(key, Some("total-n-from-bq"), n);
             }
-            Err(e) => error!(TraceType::BigQuery, error = e, "Could not get total rows",),
+            Err(e) => error!(LogKey::BigQuery, error = e, "Could not get total rows",),
         };
         let bytes_processed = self
             .query_response
@@ -334,7 +334,7 @@ impl ResultSet {
                 statsd.gauge(key, Some("bytes-from-bq"), n);
             }
             Err(e) => error!(
-                TraceType::BigQuery,
+                LogKey::BigQuery,
                 error = e,
                 "Could not get total bytes processed",
             ),

--- a/src/lib/bigquery/model.rs
+++ b/src/lib/bigquery/model.rs
@@ -31,7 +31,10 @@ use std::collections::HashMap;
 use thiserror::Error;
 use time::OffsetDateTime;
 
-use crate::telemetry::{error, StatsD, TraceType};
+use crate::{
+    error,
+    telemetry::{StatsD, TraceType},
+};
 
 #[derive(Error, Debug)]
 pub enum BQError {
@@ -291,7 +294,7 @@ impl ResultSet {
         }
     }
 
-    /// Moves the cursor froward one row from its current position.
+    /// Moves the cursor forward one row from its current position.
     /// A ResultSet cursor is initially positioned before the first row; the first call to the method next makes the
     /// first row the current row; the second call makes the second row the current row, and so on.
     pub fn next_row(&mut self) -> bool {
@@ -309,7 +312,7 @@ impl ResultSet {
     }
 
     pub fn report_stats(&self, statsd: &StatsD, key: &TraceType) {
-        statsd.gauge(key, "n-from-bq", self.row_count());
+        statsd.gauge(key, Some("n-from-bq"), self.row_count());
         let total_rows = self
             .query_response
             .total_rows
@@ -317,13 +320,9 @@ impl ResultSet {
             .unwrap_or_else(|| "-1".to_string());
         match total_rows.parse::<usize>() {
             Ok(n) => {
-                statsd.gauge(key, "total-n-from-bq", n);
+                statsd.gauge(key, Some("total-n-from-bq"), n);
             }
-            Err(e) => error(
-                &TraceType::BigQuery,
-                "Could not get total rows",
-                Some(Box::new(e)),
-            ),
+            Err(e) => error!(TraceType::BigQuery, error = e, "Could not get total rows",),
         };
         let bytes_processed = self
             .query_response
@@ -332,12 +331,12 @@ impl ResultSet {
             .unwrap_or_else(|| "-1".to_string());
         match bytes_processed.parse::<usize>() {
             Ok(n) => {
-                statsd.gauge(key, "bytes-from-bq", n);
+                statsd.gauge(key, Some("bytes-from-bq"), n);
             }
-            Err(e) => error(
-                &TraceType::BigQuery,
+            Err(e) => error!(
+                TraceType::BigQuery,
+                error = e,
                 "Could not get total bytes processed",
-                Some(Box::new(e)),
             ),
         };
     }

--- a/src/lib/controllers/corrections.rs
+++ b/src/lib/controllers/corrections.rs
@@ -10,7 +10,7 @@ use crate::{
         subscriptions::SubscriptionModel,
     },
     settings::Settings,
-    telemetry::{StatsD, TraceType},
+    telemetry::{LogKey, StatsD},
 };
 
 // TODO add statsd here
@@ -32,7 +32,7 @@ async fn build_body_from_results(
         {
             Ok(sub) => {
                 info!(
-                    TraceType::CorrectionsSubscriptionFetch,
+                    LogKey::CorrectionsSubscriptionFetch,
                     subscription_id = refund.subscription_id.as_str(),
                     refund_id = refund.refund_id.as_str(),
                     "Success fetching sub for refund"
@@ -41,7 +41,7 @@ async fn build_body_from_results(
             }
             Err(_) => {
                 error!(
-                    TraceType::CorrectionsSubscriptionFetchFailed,
+                    LogKey::CorrectionsSubscriptionFetchFailed,
                     subscription_id = refund.subscription_id.as_str(),
                     refund_id = refund.refund_id.as_str(),
                     "Failed to fetch sub for refund. Continuing..."
@@ -94,7 +94,7 @@ pub async fn by_day(
     statsd: web::Data<StatsD>,
 ) -> HttpResponse {
     statsd.incr(
-        &TraceType::CorrectionsReport,
+        &LogKey::CorrectionsReport,
         Some(&format!("{}-accessed", path.day)),
     );
     let results = get_results_for_day(pool.as_ref(), path.day).await;
@@ -107,7 +107,7 @@ pub async fn today(
     settings: web::Data<Settings>,
     statsd: web::Data<StatsD>,
 ) -> HttpResponse {
-    statsd.incr(&TraceType::CorrectionsReport, Some("today-accessed"));
+    statsd.incr(&LogKey::CorrectionsReport, Some("today-accessed"));
     let today = OffsetDateTime::now_utc().date();
     let results = get_results_for_day(pool.as_ref(), today).await;
     let body = build_body_from_results(settings.as_ref(), results, pool.as_ref()).await;

--- a/src/lib/controllers/corrections.rs
+++ b/src/lib/controllers/corrections.rs
@@ -64,7 +64,6 @@ async fn get_results_for_day(db_pool: &PgPool, day: Date) -> Vec<Refund> {
     refunds
         .fetch_by_correction_file_day(&day)
         .await
-        // TODO isn't this construct redundant?
         .unwrap_or_else(|_| panic!("Could not fetch refunds for date: {}", day))
 }
 

--- a/src/lib/controllers/custodial.rs
+++ b/src/lib/controllers/custodial.rs
@@ -1,6 +1,6 @@
 use crate::{
     error, info,
-    telemetry::{StatsD, TraceType},
+    telemetry::{StatsD, LogKey},
     version::{read_version, VERSION_FILE},
 };
 use actix_web::{web, Error, HttpResponse};
@@ -34,33 +34,33 @@ pub async fn version() -> Result<HttpResponse, Error> {
 // TODO make sure info_and_incr and error_and_incr are used in one of these
 // endpoints
 pub async fn log() -> Result<HttpResponse, Error> {
-    info!(TraceType::RequestLogTest, "Trace test with message");
+    info!(LogKey::RequestLogTest, "Trace test with message");
     info!(
-        TraceType::RequestLogTest,
+        LogKey::RequestLogTest,
         key = "value",
         "Trace test with keyword arguments"
     );
     info!(
-        TraceType::RequestLogTest,
+        LogKey::RequestLogTest,
         "Trace test with format string: {}", "Hello world"
     );
 
     let err = "NaN".parse::<usize>().unwrap_err();
-    error!(TraceType::RequestLogTest, error = err, "Trace test error",);
+    error!(LogKey::RequestLogTest, error = err, "Trace test error",);
 
     Ok(HttpResponse::Ok().body("Log test"))
 }
 
 pub async fn metrics(statsd: web::Data<StatsD>) -> Result<HttpResponse, Error> {
-    statsd.incr(&TraceType::Test, Some("test-incr"));
-    statsd.gauge(&TraceType::Test, Some("test-gauge"), 5);
+    statsd.incr(&LogKey::Test, Some("test-incr"));
+    statsd.gauge(&LogKey::Test, Some("test-gauge"), 5);
 
     let start = OffsetDateTime::now_utc();
     let hundred_millis = Duration::from_millis(100);
     thread::sleep(hundred_millis);
 
     statsd.time(
-        &TraceType::Test,
+        &LogKey::Test,
         Some("test-time"),
         OffsetDateTime::now_utc() - start,
     );

--- a/src/lib/controllers/custodial.rs
+++ b/src/lib/controllers/custodial.rs
@@ -1,5 +1,6 @@
 use crate::{
-    telemetry::{error, info, TraceType},
+    error, info,
+    telemetry::TraceType,
     version::{read_version, VERSION_FILE},
 };
 use actix_web::{Error, HttpResponse};
@@ -12,18 +13,28 @@ use actix_web::{Error, HttpResponse};
 
 #[tracing::instrument(name = "request-index")]
 pub async fn index() -> Result<HttpResponse, Error> {
-    info(&TraceType::RequestIndexSuccess, "");
     Ok(HttpResponse::Ok().body("Hello world!"))
 }
 
-pub async fn error_log() -> Result<HttpResponse, Error> {
-    let err = "NaN".parse::<usize>().unwrap_err();
-    error(
-        &TraceType::RequestErrorLogTest,
-        "Test error log report",
-        Some(Box::new(err)),
+// TODO make sure info_and_incr and error_and_incr are used in one of these
+// endpoints
+
+pub async fn log() -> Result<HttpResponse, Error> {
+    info!(TraceType::RequestLogTest, "Trace test with message");
+    info!(
+        TraceType::RequestLogTest,
+        key = "value",
+        "Trace test with keyword arguments"
     );
-    Ok(HttpResponse::Ok().body("Error log test"))
+    info!(
+        TraceType::RequestLogTest,
+        "Trace test with format string: {}", "Hello world"
+    );
+
+    let err = "NaN".parse::<usize>().unwrap_err();
+    error!(TraceType::RequestLogTest, error = err, "Trace test error",);
+
+    Ok(HttpResponse::Ok().body("Log test"))
 }
 
 pub async fn error_panic() -> Result<HttpResponse, Error> {

--- a/src/lib/controllers/custodial.rs
+++ b/src/lib/controllers/custodial.rs
@@ -1,6 +1,6 @@
 use crate::{
     error, info,
-    telemetry::{StatsD, LogKey},
+    telemetry::{LogKey, StatsD},
     version::{read_version, VERSION_FILE},
 };
 use actix_web::{web, Error, HttpResponse};
@@ -34,36 +34,32 @@ pub async fn version() -> Result<HttpResponse, Error> {
 // TODO make sure info_and_incr and error_and_incr are used in one of these
 // endpoints
 pub async fn log() -> Result<HttpResponse, Error> {
-    info!(LogKey::RequestLogTest, "Trace test with message");
+    info!(LogKey::Test, "Trace test with message");
     info!(
-        LogKey::RequestLogTest,
+        LogKey::Test,
         key = "value",
         "Trace test with keyword arguments"
     );
     info!(
-        LogKey::RequestLogTest,
+        LogKey::Test,
         "Trace test with format string: {}", "Hello world"
     );
 
     let err = "NaN".parse::<usize>().unwrap_err();
-    error!(LogKey::RequestLogTest, error = err, "Trace test error",);
+    error!(LogKey::Test, error = err, "Trace test error",);
 
     Ok(HttpResponse::Ok().body("Log test"))
 }
 
 pub async fn metrics(statsd: web::Data<StatsD>) -> Result<HttpResponse, Error> {
-    statsd.incr(&LogKey::Test, Some("test-incr"));
-    statsd.gauge(&LogKey::Test, Some("test-gauge"), 5);
+    statsd.incr(&LogKey::TestIncr);
+    statsd.gauge(&LogKey::TestGauge, 5);
 
     let start = OffsetDateTime::now_utc();
     let hundred_millis = Duration::from_millis(100);
     thread::sleep(hundred_millis);
 
-    statsd.time(
-        &LogKey::Test,
-        Some("test-time"),
-        OffsetDateTime::now_utc() - start,
-    );
+    statsd.time(&LogKey::TestTime, OffsetDateTime::now_utc() - start);
     Ok(HttpResponse::Ok().body("OK"))
 }
 

--- a/src/lib/jobs/batch_refunds.rs
+++ b/src/lib/jobs/batch_refunds.rs
@@ -7,7 +7,7 @@ use crate::{
         refunds::RefundModel,
         status_history::{Status, UpdateStatus},
     },
-    telemetry::{StatsD, TraceType},
+    telemetry::{LogKey, StatsD},
 };
 
 pub async fn batch_refunds_by_day(db_pool: &Pool<Postgres>, statsd: &StatsD) {
@@ -18,7 +18,7 @@ pub async fn batch_refunds_by_day(db_pool: &Pool<Postgres>, statsd: &StatsD) {
         .await
         .expect("Could not retrieve refunds from DB.");
     statsd.gauge(
-        &TraceType::BatchRefunds,
+        &LogKey::BatchRefunds,
         Some("n-not-reported"),
         not_reported_refunds.len(),
     );
@@ -41,7 +41,7 @@ pub async fn batch_refunds_by_day(db_pool: &Pool<Postgres>, statsd: &StatsD) {
             Ok(r) => {
                 info_and_incr!(
                     statsd,
-                    TraceType::BatchRefundsUpdate,
+                    LogKey::BatchRefundsUpdate,
                     refund_id = &r.refund_id.as_str(),
                     "Success updating refund"
                 );
@@ -49,7 +49,7 @@ pub async fn batch_refunds_by_day(db_pool: &Pool<Postgres>, statsd: &StatsD) {
             Err(e) => {
                 error_and_incr!(
                     statsd,
-                    TraceType::BatchRefundsUpdateFailed,
+                    LogKey::BatchRefundsUpdateFailed,
                     error = e,
                     refund_id = &refund.refund_id.as_str(),
                     "Could not update refund to be reported"

--- a/src/lib/jobs/batch_refunds.rs
+++ b/src/lib/jobs/batch_refunds.rs
@@ -2,7 +2,7 @@ use sqlx::{Pool, Postgres};
 use time::OffsetDateTime;
 
 use crate::{
-    error, error_and_incr, info, info_and_incr,
+    error_and_incr, info_and_incr,
     models::{
         refunds::RefundModel,
         status_history::{Status, UpdateStatus},
@@ -18,8 +18,7 @@ pub async fn batch_refunds_by_day(db_pool: &Pool<Postgres>, statsd: &StatsD) {
         .await
         .expect("Could not retrieve refunds from DB.");
     statsd.gauge(
-        &LogKey::BatchRefunds,
-        Some("n-not-reported"),
+        &LogKey::BatchRefundsNNotReported,
         not_reported_refunds.len(),
     );
     for mut refund in not_reported_refunds {

--- a/src/lib/jobs/check_refunds.rs
+++ b/src/lib/jobs/check_refunds.rs
@@ -138,12 +138,11 @@ pub async fn fetch_and_process_refunds(bq: &BQClient, db_pool: &Pool<Postgres>, 
                                 sqlx::Error::Database(e) => {
                                     // 23505 is the code for unique constraints e.g. duplicate flow id issues
                                     if e.code() == Some(std::borrow::Cow::Borrowed("23505")) {
-                                        // TODO definitely need metrics here.
                                         error_and_incr!(
                                             statsd,
                                             LogKey::CheckRefundsRefundCreateDuplicateKeyViolation,
                                             error = e,
-                                            refund_id = &r.refund_id.as_str(), // TODO will this actually work?
+                                            refund_id = &r.refund_id.as_str(),
                                             "Duplicate key violation"
                                         );
                                     } else {
@@ -151,7 +150,7 @@ pub async fn fetch_and_process_refunds(bq: &BQClient, db_pool: &Pool<Postgres>, 
                                             statsd,
                                             LogKey::CheckRefundsRefundCreateDatabaseError,
                                             error = e,
-                                            refund_id = &r.refund_id.as_str(), // TODO will this actually work?
+                                            refund_id = &r.refund_id.as_str(),
                                             "Database error while creating refund. Continuing..."
                                         );
                                     }
@@ -162,7 +161,7 @@ pub async fn fetch_and_process_refunds(bq: &BQClient, db_pool: &Pool<Postgres>, 
                                         statsd,
                                         LogKey::CheckRefundsRefundCreateFailed,
                                         error = e,
-                                        refund_id = &r.refund_id.as_str(), // TODO will this actually work?
+                                        refund_id = &r.refund_id.as_str(),
                                         "Unexpected error while creating refund. Continuing..."
                                     );
                                     continue;

--- a/src/lib/jobs/check_refunds.rs
+++ b/src/lib/jobs/check_refunds.rs
@@ -93,7 +93,7 @@ pub async fn fetch_and_process_refunds(bq: &BQClient, db_pool: &Pool<Postgres>, 
                     statsd,
                     LogKey::CheckRefundsRefundDataChanged,
                     refund_id = refund.refund_id.as_str(),
-                    "Data for refund is changed. Continuing..."
+                    "Data for refund is changed. Updating..."
                 );
                 refund.subscription_id = r.subscription_id;
                 refund.refund_created = r.refund_created;

--- a/src/lib/jobs/check_refunds.rs
+++ b/src/lib/jobs/check_refunds.rs
@@ -3,7 +3,7 @@ use uuid::Uuid;
 
 use crate::{
     bigquery::client::{BQClient, BQError, ResultSet},
-    error, error_and_incr, info, info_and_incr,
+    error_and_incr, info_and_incr,
     models::{
         refunds::{PartialRefund, Refund, RefundModel},
         status_history::{Status, UpdateStatus},
@@ -62,7 +62,8 @@ pub async fn fetch_and_process_refunds(bq: &BQClient, db_pool: &Pool<Postgres>, 
             .await
             .is_ok();
         if !have_sub {
-            error!(
+            error_and_incr!(
+                statsd,
                 LogKey::CheckRefundsSubscriptionMissingFromDatabase,
                 subscription_id = r.subscription_id.as_str(),
                 refund_id = r.refund_id.as_str(),

--- a/src/lib/jobs/check_subscriptions.rs
+++ b/src/lib/jobs/check_subscriptions.rs
@@ -8,7 +8,7 @@ use crate::{
         aic::AICModel,
         subscriptions::{PartialSubscription, Subscription, SubscriptionModel},
     },
-    telemetry::{StatsD, TraceType},
+    telemetry::{LogKey, StatsD},
 };
 
 fn make_subscription_from_bq_row(rs: &ResultSet) -> Result<Subscription, BQError> {
@@ -41,7 +41,7 @@ pub async fn fetch_and_process_new_subscriptions(
     // Get all results from bigquery table that stores new subscription reports
     let query = "SELECT * FROM `cjms_bigquery.subscriptions_v1`;";
     let mut rs = bq.get_bq_results(query).await;
-    rs.report_stats(statsd, &TraceType::CheckSubscriptions);
+    rs.report_stats(statsd, &LogKey::CheckSubscriptions);
     while rs.next_row() {
         // If can't deserialize e.g. required fields are not available log and move on.
         let mut sub = match make_subscription_from_bq_row(&rs) {

--- a/src/lib/jobs/check_subscriptions.rs
+++ b/src/lib/jobs/check_subscriptions.rs
@@ -81,7 +81,7 @@ pub async fn fetch_and_process_new_subscriptions(
                         statsd,
                         LogKey::CheckSubscriptionsAicFetchFromArchive,
                         aic_id = aic.id.to_string().as_str(),
-                        "Successfully fetched aic from archive table",
+                        "AIC was fetched from archive table.",
                     );
                     (aic, true)
                 }

--- a/src/lib/jobs/check_subscriptions.rs
+++ b/src/lib/jobs/check_subscriptions.rs
@@ -4,6 +4,7 @@ use uuid::Uuid;
 
 use crate::{
     bigquery::client::{BQClient, BQError, ResultSet},
+    error_and_incr, info_and_incr,
     models::{
         aic::AICModel,
         subscriptions::{PartialSubscription, Subscription, SubscriptionModel},
@@ -46,39 +47,50 @@ pub async fn fetch_and_process_new_subscriptions(
         // If can't deserialize e.g. required fields are not available log and move on.
         let mut sub = match make_subscription_from_bq_row(&rs) {
             Ok(sub) => {
-                // TODO - LOGGING
-                println!(
-                    "Successfully deserialized subscription from bq row: {}",
-                    sub.id
+                info_and_incr!(
+                    statsd,
+                    LogKey::CheckSubscriptionsDeserializeBigQuery,
+                    subscription_id = sub.id.to_string().as_str(),
+                    "Successfully deserialized subscription from BigQuery row",
                 );
                 sub
             }
             Err(e) => {
-                // TODO - LOGGING - Log information and get a metric
-                println!(
-                    "Failed to make subscription for bq result row. {:?}. Continuing...",
-                    e
+                error_and_incr!(
+                    statsd,
+                    LogKey::CheckSubscriptionsDeserializeBigQueryFailed,
+                    error = e,
+                    "Failed to make subscription for BigQuery result row. Continuing...",
                 );
                 continue;
             }
         };
         let (aic, aic_found_in_archive) = match aics.fetch_one_by_flow_id(&sub.flow_id).await {
             Ok(aic) => {
-                // TODO - LOGGING
-                println!("Succesfully fetched aic: {}.", aic.id);
+                info_and_incr!(
+                    statsd,
+                    LogKey::CheckSubscriptionsAicFetch,
+                    aic_id = aic.id.to_string().as_str(),
+                    "Successfully fetched aic",
+                );
                 (aic, false)
             }
             Err(_) => match aics.fetch_one_by_flow_id_from_archive(&sub.flow_id).await {
                 Ok(aic) => {
-                    // TODO - LOGGING - Note that we had to pull from archive table
-                    println!("AIC {} was retrieved from archive table.", aic.id);
+                    info_and_incr!(
+                        statsd,
+                        LogKey::CheckSubscriptionsAicFetchFromArchive,
+                        aic_id = aic.id.to_string().as_str(),
+                        "Successfully fetched aic from archive table",
+                    );
                     (aic, true)
                 }
                 Err(e) => {
-                    // TODO - LOGGING
-                    println!(
-                        "Error getting aic for subscription: {:?}. Continuing....",
-                        e
+                    error_and_incr!(
+                        statsd,
+                        LogKey::CheckSubscriptionsAicFetchFailed,
+                        error = e,
+                        "Error getting aic for subscription. Continuing...",
                     );
                     continue;
                 }
@@ -92,12 +104,21 @@ pub async fn fetch_and_process_new_subscriptions(
         if !aic_found_in_archive {
             match aics.archive_aic(&aic).await {
                 Ok(_) => {
-                    // TODO - LOGGING
-                    println!("Successfully archived aic: {}.", aic.id);
+                    info_and_incr!(
+                        statsd,
+                        LogKey::CheckSubscriptionsAicArchive,
+                        aic_id = aic.id.to_string().as_str(),
+                        "Successfully archived aic",
+                    );
                 }
                 Err(e) => {
-                    // TODO - LOGGING
-                    println!("Failed to archive aic entry: {:?}. Continuing...", e);
+                    error_and_incr!(
+                        statsd,
+                        LogKey::CheckSubscriptionsAicArchiveFailed,
+                        error = e,
+                        aic_id = aic.id.to_string().as_str(),
+                        "Failed to archive aic entry. Continuing...",
+                    );
                     continue;
                 }
             };
@@ -105,27 +126,38 @@ pub async fn fetch_and_process_new_subscriptions(
         // Save the new subscription entry
         match subscriptions.create_from_sub(&sub).await {
             Ok(sub) => {
-                // TODO - LOGGING
-                println!("Successfully created sub: {}.", sub.id);
+                info_and_incr!(
+                    statsd,
+                    LogKey::CheckSubscriptionsSubscriptionCreate,
+                    sub_id = sub.id.to_string().as_str(),
+                    "Successfully created subscription"
+                );
             }
             Err(e) => match e {
                 sqlx::Error::Database(e) => {
                     // 23505 is the code for unique constraints e.g. duplicate flow id issues
                     if e.code() == Some(std::borrow::Cow::Borrowed("23505")) {
-                        // TODO - LOGGING - add some specific logging / metrics around duplicate key issues.
-                        // This could help us see that we have an ETL issue.
-                        println!("Duplicate Key Violation");
+                        error_and_incr!(
+                            statsd,
+                            LogKey::CheckSubscriptionsSubscriptionCreateDuplicateKeyViolation,
+                            error = e,
+                            "Duplicate key violation"
+                        );
                     }
-                    println!(
-                        "DatabaseError error while creating subscription {:?}. Continuing...",
-                        e
+                    error_and_incr!(
+                        statsd,
+                        LogKey::CheckSubscriptionsSubscriptionCreateDatabaseError,
+                        error = e,
+                        "Database error while creating subscription. Continuing..."
                     );
                     continue;
                 }
                 _ => {
-                    println!(
-                        "Unexpected error while creating subscription {:?}. Continuing...",
-                        e
+                    error_and_incr!(
+                        statsd,
+                        LogKey::CheckSubscriptionsSubscriptionCreateFailed,
+                        error = e,
+                        "Unexpected error while creating subscription. Continuing...",
                     );
                     continue;
                 }

--- a/src/lib/jobs/report_subscriptions.rs
+++ b/src/lib/jobs/report_subscriptions.rs
@@ -3,7 +3,7 @@ use sqlx::{Pool, Postgres};
 use crate::{
     cj::client::CJS2SClient,
     models::{status_history::Status, subscriptions::SubscriptionModel},
-    telemetry::{StatsD, TraceType},
+    telemetry::{StatsD, LogKey},
 };
 
 // TODO - LOGGING
@@ -21,7 +21,7 @@ pub async fn report_subscriptions_to_cj(
         .await
         .expect("Could not retrieve subscriptions from DB.");
     statsd.gauge(
-        &TraceType::ReportSubscriptions,
+        &LogKey::ReportSubscriptions,
         Some("n-not-reported"),
         not_reported_subscriptions.len(),
     );

--- a/src/lib/jobs/report_subscriptions.rs
+++ b/src/lib/jobs/report_subscriptions.rs
@@ -22,7 +22,7 @@ pub async fn report_subscriptions_to_cj(
         .expect("Could not retrieve subscriptions from DB.");
     statsd.gauge(
         &TraceType::ReportSubscriptions,
-        "n-not-reported",
+        Some("n-not-reported"),
         not_reported_subscriptions.len(),
     );
     for sub in not_reported_subscriptions {

--- a/src/lib/jobs/report_subscriptions.rs
+++ b/src/lib/jobs/report_subscriptions.rs
@@ -84,28 +84,41 @@ pub async fn report_subscriptions_to_cj(
                         .await
                     {
                         Ok(_) => {
-                            println!("200 Success for sub: {}", &sub.id);
+                            info_and_incr!(
+                                statsd,
+                                LogKey::ReportSubscriptionReportToCj,
+                                sub_id = &sub.id.to_string().as_str(),
+                                "Successfully reported sub to CJ; received 200 status"
+                            );
                         }
                         Err(e) => {
-                            println!(
-                                "Could not mark subscription {} as reported. But it has been. {}",
-                                &sub.id, e
+                            error_and_incr!(
+                                statsd,
+                                LogKey::ReportSubscriptionReportToCjButCouldNotMarkReported,
+                                error = e,
+                                sub_id = &sub.id.to_string().as_str(),
+                                "Successfully reported sub to CJ; received 200 status, but could not mark the sub as reported locally."
                             );
                         }
                     };
                     false
                 } else {
-                    println!(
-                        "Not 200 Success for sub: {}. Marking Not Reported.",
-                        &sub.id
+                    error_and_incr!(
+                        statsd,
+                        LogKey::ReportSubscriptionReportToCjFailed,
+                        sub_id = &sub.id.to_string().as_str(),
+                        "Could not report sub to CJ; received non-200 status."
                     );
                     true
                 }
             }
             Err(e) => {
-                println!(
-                    "Report_subscription errored. Marking sub {} not reported. {}",
-                    &sub.id, e
+                error_and_incr!(
+                    statsd,
+                    LogKey::ReportSubscriptionReportToCjFailed,
+                    error = e,
+                    sub_id = &sub.id.to_string().as_str(),
+                    "Could not report sub to CJ; unknown application failure."
                 );
                 true
             }
@@ -116,12 +129,20 @@ pub async fn report_subscriptions_to_cj(
                 .await
             {
                 Ok(_) => {
-                    println!("Successfully marked as NotReported.");
+                    info_and_incr!(
+                        statsd,
+                        LogKey::ReportSubscriptionMarkNotReported,
+                        sub_id = &sub.id.to_string().as_str(),
+                        "Successfully marked as NotReported."
+                    );
                 }
                 Err(e) => {
-                    println!(
-                        "Could not mark subscription {} as not_reported. {}",
-                        &sub.id, e
+                    error_and_incr!(
+                        statsd,
+                        LogKey::ReportSubscriptionMarkNotReportedFailed,
+                        error = e,
+                        sub_id = &sub.id.to_string().as_str(),
+                        "Could not mark subscription as NotReported."
                     );
                 }
             }

--- a/src/lib/jobs/report_subscriptions.rs
+++ b/src/lib/jobs/report_subscriptions.rs
@@ -27,7 +27,6 @@ pub async fn report_subscriptions_to_cj(
         let next_status = match sub.aic_expires {
             Some(aic_expires) => {
                 if aic_expires < sub.subscription_created {
-                    // TODO info or error?
                     error_and_incr!(
                         statsd,
                         LogKey::ReportSubscriptionsAicExpiredBeforeSubscriptionCreated,
@@ -40,7 +39,6 @@ pub async fn report_subscriptions_to_cj(
                 }
             }
             None => {
-                // TODO info or error?
                 error_and_incr!(
                     statsd,
                     LogKey::ReportSubscriptionsSubscriptionHasNoAicExpiry,

--- a/src/lib/jobs/report_subscriptions.rs
+++ b/src/lib/jobs/report_subscriptions.rs
@@ -27,7 +27,7 @@ pub async fn report_subscriptions_to_cj(
         let next_status = match sub.aic_expires {
             Some(aic_expires) => {
                 if aic_expires < sub.subscription_created {
-                    error_and_incr!(
+                    info_and_incr!(
                         statsd,
                         LogKey::ReportSubscriptionsAicExpiredBeforeSubscriptionCreated,
                         sub_id = &sub.id.to_string().as_str(),

--- a/src/lib/models/aic.rs
+++ b/src/lib/models/aic.rs
@@ -2,7 +2,7 @@ use sqlx::{query, query_as, Error, PgPool};
 use time::{Duration, OffsetDateTime};
 use uuid::Uuid;
 
-use crate::{error, settings::Settings, telemetry::TraceType};
+use crate::{error, settings::Settings, telemetry::LogKey};
 
 #[derive(Debug)]
 pub struct AIC {
@@ -70,7 +70,7 @@ impl AICModel<'_> {
         .await
         .map_err(|e| {
             error!(
-                TraceType::AicRecordCreateFailed,
+                LogKey::AicRecordCreateFailed,
                 error = e,
                 "Failed to execute query"
             );

--- a/src/lib/models/aic.rs
+++ b/src/lib/models/aic.rs
@@ -2,10 +2,7 @@ use sqlx::{query, query_as, Error, PgPool};
 use time::{Duration, OffsetDateTime};
 use uuid::Uuid;
 
-use crate::{
-    settings::Settings,
-    telemetry::{error, TraceType},
-};
+use crate::{error, settings::Settings, telemetry::TraceType};
 
 #[derive(Debug)]
 pub struct AIC {
@@ -72,10 +69,10 @@ impl AICModel<'_> {
         .fetch_one(self.db_pool)
         .await
         .map_err(|e| {
-            error(
-                &TraceType::AicRecordCreateFailed,
-                &format!("Failed to execute query: {:?}", e),
-                None,
+            error!(
+                TraceType::AicRecordCreateFailed,
+                error = e,
+                "Failed to execute query"
             );
             e
         })

--- a/src/lib/models/status_history.rs
+++ b/src/lib/models/status_history.rs
@@ -5,6 +5,8 @@ use serde_json::{from_value, json, Value as JsonValue};
 use strum_macros::{Display as EnumToString, EnumString};
 use time::OffsetDateTime;
 
+use crate::{error, telemetry::LogKey};
+
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, EnumToString, EnumString)]
 pub enum Status {
     NotReported,
@@ -34,8 +36,12 @@ impl StatusHistory {
         let status_history: StatusHistory = match from_value(v.clone()) {
             Ok(v) => v,
             Err(e) => {
-                // TODO - LOGGING
-                println!("Error deserializing status_history: {:?} {}", v, e);
+                error!(
+                    LogKey::StatusHistoryDeserializeError,
+                    error = e,
+                    v = v.to_string().as_str(),
+                    "Error deserializing status_history"
+                );
                 StatusHistory { entries: vec![] }
             }
         };

--- a/src/lib/telemetry.rs
+++ b/src/lib/telemetry.rs
@@ -278,3 +278,22 @@ impl StatsD {
             .ok();
     }
 }
+
+#[cfg(test)]
+pub mod test_telemetry {
+    use super::*;
+
+    #[test]
+    fn get_log_key_with_valid_suffix() {
+        let expected = LogKey::TestEnding;
+        let actual = LogKey::Test.add_suffix("ending");
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn get_log_key_with_invalid_suffix() {
+        let expected = LogKey::Test;
+        let actual = LogKey::Test.add_suffix("this-wont-work");
+        assert_eq!(expected, actual);
+    }
+}

--- a/src/lib/telemetry.rs
+++ b/src/lib/telemetry.rs
@@ -16,10 +16,9 @@ use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Registry};
 use crate::settings::Settings;
 use crate::version::{read_version, VERSION_FILE};
 
-// TODO - Rename to something more generic e.g. LoggingKey
 #[derive(Debug, EnumToString, PartialEq, Eq)]
 #[strum(serialize_all = "kebab_case")]
-pub enum TraceType {
+pub enum LogKey {
     AicRecordCreate,
     AicRecordCreateFailed,
     BatchRefunds,
@@ -159,7 +158,7 @@ impl StatsD {
             client: Arc::new(StatsdClient::from_sink("cjms", sink)),
         }
     }
-    pub fn incr(&self, key: &TraceType, suffix: Option<&str>) {
+    pub fn incr(&self, key: &LogKey, suffix: Option<&str>) {
         let tag = match suffix {
             Some(s) => format!("{}-{}", key, s.to_lowercase()),
             None => key.to_string(),
@@ -168,7 +167,7 @@ impl StatsD {
             .incr(&tag)
             .map_err(|e| {
                 error!(
-                    TraceType::StatsDError,
+                    LogKey::StatsDError,
                     error = e,
                     tag = tag.as_str(),
                     "Could not increment statsd tag"
@@ -176,7 +175,7 @@ impl StatsD {
             })
             .ok();
     }
-    pub fn gauge(&self, key: &TraceType, suffix: Option<&str>, v: usize) {
+    pub fn gauge(&self, key: &LogKey, suffix: Option<&str>, v: usize) {
         let tag = match suffix {
             Some(s) => format!("{}-{}", key, s.to_lowercase()),
             None => key.to_string(),
@@ -186,7 +185,7 @@ impl StatsD {
             .gauge(&tag, v)
             .map_err(|e| {
                 error!(
-                    TraceType::StatsDError,
+                    LogKey::StatsDError,
                     error = e,
                     value = v,
                     tag = tag.as_str(),
@@ -195,7 +194,7 @@ impl StatsD {
             })
             .ok();
     }
-    pub fn time(&self, key: &TraceType, suffix: Option<&str>, t: Duration) {
+    pub fn time(&self, key: &LogKey, suffix: Option<&str>, t: Duration) {
         let tag = match suffix {
             Some(s) => format!("{}-{}", key, s.to_lowercase()),
             None => key.to_string(),
@@ -205,7 +204,7 @@ impl StatsD {
             .time(&tag, milliseconds as u64)
             .map_err(|e| {
                 error!(
-                    TraceType::StatsDError,
+                    LogKey::StatsDError,
                     error = e,
                     time = format!("{:?}", t).as_str(),
                     tag = tag.as_str(),

--- a/src/lib/telemetry.rs
+++ b/src/lib/telemetry.rs
@@ -24,96 +24,93 @@ pub enum LogKey {
     AicRecordCreate,
     AicRecordCreateFailed,
     BatchRefunds,
-    BigQuery,
-    CheckRefunds,
-    CheckSubscriptions,
-    Cleanup,
-    CorrectionsReport,
-    ReportSubscriptions,
-    RequestLogTest,
-    StatsDError,
-    Test, // For test cases
-    WebApp,
-
-    // TODO sort
-    CorrectionsSubscriptionFetch,
-    CorrectionsSubscriptionFetchFailed,
+    BatchRefundsEnding,
+    BatchRefundsNNotReported,
+    BatchRefundsStarting,
+    BatchRefundsTimer,
     BatchRefundsUpdate,
     BatchRefundsUpdateFailed,
+    BigQuery,
+    CheckRefunds,
+    CheckRefundsBytesFromBq,
     CheckRefundsDeserializeBigQuery,
     CheckRefundsDeserializeBigQueryFailed,
-    CheckRefundsSubscriptionMissingFromDatabase,
+    CheckRefundsEnding,
+    CheckRefundsNFromBq,
+    CheckRefundsRefundCreate,
+    CheckRefundsRefundCreateDatabaseError,
+    CheckRefundsRefundCreateDuplicateKeyViolation,
+    CheckRefundsRefundCreateFailed,
     CheckRefundsRefundDataChanged,
     CheckRefundsRefundDataUnchanged,
+    CheckRefundsRefundFetchFailed,
     CheckRefundsRefundUpdate,
     CheckRefundsRefundUpdateFailed,
-    CheckRefundsRefundCreate,
-    CheckRefundsRefundCreateDuplicateKeyViolation,
-    CheckRefundsRefundCreateDatabaseError,
-    CheckRefundsRefundCreateFailed,
-    CheckRefundsRefundFetchFailed,
-    CheckSubscriptionsDeserializeBigQuery,
-    BatchRefundsStarting,
-    BatchRefundsEnding,
-    BatchRefundsTimer,
     CheckRefundsStarting,
-    CheckRefundsEnding,
+    CheckRefundsSubscriptionMissingFromDatabase,
     CheckRefundsTimer,
-    CheckSubscriptionsStarting,
-    CheckSubscriptionsEnding,
-    CheckSubscriptionsTimer,
-    CleanupStarting,
-    CleanupEnding,
-    CleanupTimer,
-    ReportSubscriptionsStarting,
-    ReportSubscriptionsEnding,
-    ReportSubscriptionsTimer,
-    WebAppStarting,
-    WebAppEnding,
-    WebAppTimer,
-    TestStarting,
-    TestEnding,
-    TestTimer,
-    CheckRefundsNFromBq,
-    CheckSubscriptionsNFromBq,
     CheckRefundsTotalNFromBq,
-    CheckSubscriptionsTotalNFromBq,
-    CheckRefundsBytesFromBq,
-    CheckSubscriptionsBytesFromBq,
-    ReportSubscriptionsNNotReported,
-    TestIncr,
-    TestGauge,
-    TestTime,
-    BatchRefundsNNotReported,
-    CorrectionsReportByDayAccessed,
-    CorrectionsReportTodayAccessed,
-    CheckSubscriptionsDeserializeBigQueryFailed,
-    CheckSubscriptionsAicFetch,
-    CheckSubscriptionsAicFetchFromArchive,
-    CheckSubscriptionsAicFetchFailed,
+    CheckSubscriptions,
     CheckSubscriptionsAicArchive,
     CheckSubscriptionsAicArchiveFailed,
+    CheckSubscriptionsAicFetch,
+    CheckSubscriptionsAicFetchFailed,
+    CheckSubscriptionsAicFetchFromArchive,
+    CheckSubscriptionsBytesFromBq,
+    CheckSubscriptionsDeserializeBigQuery,
+    CheckSubscriptionsDeserializeBigQueryFailed,
+    CheckSubscriptionsEnding,
+    CheckSubscriptionsNFromBq,
+    CheckSubscriptionsStarting,
     CheckSubscriptionsSubscriptionCreate,
-    CheckSubscriptionsSubscriptionCreateDuplicateKeyViolation,
     CheckSubscriptionsSubscriptionCreateDatabaseError,
+    CheckSubscriptionsSubscriptionCreateDuplicateKeyViolation,
     CheckSubscriptionsSubscriptionCreateFailed,
+    CheckSubscriptionsTimer,
+    CheckSubscriptionsTotalNFromBq,
+    Cleanup,
     CleanupAicArchive,
     CleanupAicArchiveFailed,
-    ReportSubscriptionsAicExpiredBeforeSubscriptionCreated,
-    ReportSubscriptionsSubscriptionHasNoAicExpiry,
+    CleanupEnding,
+    CleanupStarting,
+    CleanupTimer,
+    CorrectionsReport,
+    CorrectionsReportByDayAccessed,
+    CorrectionsReportTodayAccessed,
+    CorrectionsSubscriptionFetch,
+    CorrectionsSubscriptionFetchFailed,
+    ReportSubscriptionMarkNotReported,
+    ReportSubscriptionMarkNotReportedFailed,
     ReportSubscriptionMarkWillNotReport,
     ReportSubscriptionMarkWillNotReportFailed,
     ReportSubscriptionReportToCj,
     ReportSubscriptionReportToCjButCouldNotMarkReported,
     ReportSubscriptionReportToCjFailed,
-    ReportSubscriptionMarkNotReported,
-    ReportSubscriptionMarkNotReportedFailed,
+    ReportSubscriptions,
+    ReportSubscriptionsAicExpiredBeforeSubscriptionCreated,
+    ReportSubscriptionsEnding,
+    ReportSubscriptionsNNotReported,
+    ReportSubscriptionsStarting,
+    ReportSubscriptionsSubscriptionHasNoAicExpiry,
+    ReportSubscriptionsTimer,
+    RequestLogTest,
+    StatsDError,
     StatusHistoryDeserializeError,
+    WebApp,
+    WebAppEnding,
+    WebAppStarting,
+    WebAppTimer,
+
+    // For test cases
+    Test,
+    TestEnding,
+    TestGauge,
+    TestIncr,
+    TestStarting,
+    TestTime,
+    TestTimer,
 }
 
-// TODO doc
-// TODO test
-// TODO doc weird nit about suffixes and what happens when they fail
 impl LogKey {
     pub fn add_suffix(&self, suffix: &str) -> LogKey {
         let s = format!("{}-{}", &self.to_string(), suffix);
@@ -121,8 +118,6 @@ impl LogKey {
 
         match LogKey::from_str(s_str) {
             Ok(v) => v,
-            // TODO why can't I just return self ...
-            // TODO do we need to deal with the unwrap? Hope not
             Err(_) => LogKey::from_str(&self.to_string()).unwrap(),
         }
     }
@@ -205,7 +200,6 @@ macro_rules! error {
 #[macro_export]
 macro_rules! info_and_incr {
     ( $statsd_client:expr, $trace_type:expr, $($arg:tt)+ ) => {
-        // TODO is this the right way to handle this import?
         crate::info!($trace_type.to_string().as_str(), $($arg)*);
         $statsd_client.incr(&$trace_type);
     }
@@ -215,7 +209,6 @@ macro_rules! info_and_incr {
 #[macro_export]
 macro_rules! error_and_incr {
     ( $statsd_client:expr, $trace_type:expr, $($arg:tt)+ ) => {
-        // TODO is this the right way to handle this import?
         crate::error!($trace_type.to_string().as_str(), $($arg)*);
         $statsd_client.incr(&$trace_type);
     }

--- a/src/lib/telemetry.rs
+++ b/src/lib/telemetry.rs
@@ -104,8 +104,10 @@ pub enum LogKey {
     // For test cases
     Test,
     TestEnding,
+    TestErrorIncr,
     TestGauge,
     TestIncr,
+    TestInfoIncr,
     TestStarting,
     TestTime,
     TestTimer,

--- a/src/lib/telemetry.rs
+++ b/src/lib/telemetry.rs
@@ -103,6 +103,12 @@ pub enum LogKey {
     ReportSubscriptionsSubscriptionHasNoAicExpiry,
     ReportSubscriptionMarkWillNotReport,
     ReportSubscriptionMarkWillNotReportFailed,
+    ReportSubscriptionReportToCj,
+    ReportSubscriptionReportToCjButCouldNotMarkReported,
+    ReportSubscriptionReportToCjFailed,
+    ReportSubscriptionMarkNotReported,
+    ReportSubscriptionMarkNotReportedFailed,
+    StatusHistoryDeserializeError,
 }
 
 // TODO doc

--- a/tests/integration/appconfig.rs
+++ b/tests/integration/appconfig.rs
@@ -1,6 +1,6 @@
 use lib::{
     appconfig::CJ,
-    telemetry::TraceType,
+    telemetry::LogKey,
     version::{write_version, VersionInfo, VERSION_FILE},
 };
 use serial_test::serial;
@@ -22,7 +22,7 @@ async fn test_creating_and_shutting_down_a_cj_object() {
     write_version(VERSION_FILE, &version_data);
     env::set_var("BQ_ACCESS_TOKEN", "a token");
 
-    let cj = CJ::new(TraceType::Test).await;
+    let cj = CJ::new(LogKey::Test).await;
     assert!(!cj.db_pool.is_closed());
     cj.shutdown().await.expect("Failed to complete shutdown");
     assert!(cj.db_pool.is_closed());


### PR DESCRIPTION
TODO 

- [x] Add statsd to `build_body_from_results`
- [x] Test `info_and_incr!` and `error_and_incr!` within one of the custodial endpoints (either log or metrics)
- [ ] Document and test `LogKey::add_suffix`, including docs about the behaviour that happens if an enum key is not found
- [ ] Doc macro usage, including examples and a note about what happens if you put the `error` key in the wrong order