### PR TITLE
Document telemetry methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,24 @@ magically compatible.
 In both cases the reason was because the versions of `time` and `uuid` that I had installed were ahead of what sqlx
 currently supports. This meant that the, I think, trait implementations for them to interoperate weren't present.
 
-### Working with statsd
+### Working with logs and metrics
+
+The telemetry module contains utilities for writing out logs and metrics. The most common pattern we use it to use a macro that writes out a log with a pre-defined key, while at the same time incrementing a statsd counter with the same name. The name of the log key should be a known value in the `LogKey` macro.
+
+For example:
+
+```rust
+info_and_incr!(
+    StatsD::new(&settings),
+    LogKey::CleanupAicArchive,
+    key = "value",
+    "Some log message"
+)
+```
+
+The value of the `LogKey` enum will be stringified to kebab case before it is sent to the logger and statsd. Additionally statsd adds a project prefix. So for this example, the final result will be to write a Mozlog-compatible log message to stdout with a `type` value of `cleanup-aic-archive`, and increment a statsd counter with the name `cjms.cleanup-aic-archive`.
+
+#### Running a local statsd client
 
 If configured using the defaults from settings.yaml.example, the statsd client
 will send metrics to a statsd server on localhost at UDP port 8125. Since statsd

--- a/src/lib/jobs/check_refunds.rs
+++ b/src/lib/jobs/check_refunds.rs
@@ -67,6 +67,7 @@ pub async fn fetch_and_process_refunds(bq: &BQClient, db_pool: &Pool<Postgres>, 
                 LogKey::CheckRefundsSubscriptionMissingFromDatabase,
                 subscription_id = r.subscription_id.as_str(),
                 refund_id = r.refund_id.as_str(),
+                "Subscription related to refund missing from database",
             );
             continue;
         }

--- a/src/lib/telemetry.rs
+++ b/src/lib/telemetry.rs
@@ -150,15 +150,8 @@ impl LogKey {
     /// # Examples
     ///
     /// ```
-    /// pub fn abstract_logger(base_key: &LogKey) {
-    ///     // Do some important work here
-    ///
-    ///     info!(&key.add_suffix("starting"), "Message");
-    /// }
-    ///
-    /// abstract_logger(statsd, &LogKey::Cleanup);  // Logs to "CleanupStarting"
-    /// abstract_logger(statsd, &LogKey::ReportSubscriptions);  // Logs to "ReportSubscriptionsStarting"
-    ///
+    /// LogKey::Cleanup.add_suffix("starting"); // returns LogKey::CleanupStarting
+    /// LogKey::Cleanup.add_suffix("invalid"); // produces an invalid enum value; returns LogKey::Cleanup
     /// ```
     pub fn add_suffix(&self, suffix: &str) -> LogKey {
         let s = format!("{}-{}", &self.to_string(), suffix);
@@ -281,8 +274,9 @@ macro_rules! error {
 /// name.
 ///
 /// The macro expects a `StatsD` client as its first argument, followed by a
-/// `LogKey` enum value. Aside from this, the macro behaves exactly like the
-/// `info!` macro.
+/// `LogKey` enum value. The name of the log trace and the statsd counter will
+/// be the stringified form of the LogKey enum value. Aside from this, the macro
+/// behaves exactly like the `info!` macro.
 ///
 /// # Examples
 ///

--- a/src/lib/telemetry.rs
+++ b/src/lib/telemetry.rs
@@ -124,12 +124,12 @@ pub enum LogKey {
 
     // For test cases
     Test,
+    TestEnding,
     TestErrorIncr,
     TestGauge,
     TestIncr,
     TestInfoIncr,
     TestStarting,
-    TestSuffix,
     TestTime,
     TestTimer,
 }
@@ -408,8 +408,8 @@ pub mod test_telemetry {
 
     #[test]
     fn get_log_key_with_valid_suffix() {
-        let expected = LogKey::TestSuffix;
-        let actual = LogKey::Test.add_suffix("suffix");
+        let expected = LogKey::TestStarting;
+        let actual = LogKey::Test.add_suffix("starting");
         assert_eq!(expected, actual);
     }
 


### PR DESCRIPTION
Fixes PSP-387

Also, add a missing log message to one event in `check_refunds` that was showing up as an unlabelled event in Sentry.