### PR TITLE
Refactor add_suffix

### DIFF
--- a/src/lib/telemetry.rs
+++ b/src/lib/telemetry.rs
@@ -18,7 +18,7 @@ use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Registry};
 use crate::settings::Settings;
 use crate::version::{read_version, VERSION_FILE};
 
-#[derive(Debug, EnumToString, EnumString, PartialEq, Eq)]
+#[derive(Debug, EnumToString, EnumString, PartialEq, Eq, Clone, Copy)]
 #[strum(serialize_all = "kebab_case")]
 pub enum LogKey {
     AicRecordCreate,
@@ -136,12 +136,13 @@ pub enum LogKey {
 
 impl LogKey {
     pub fn add_suffix(&self, suffix: &str) -> LogKey {
-        let s = format!("{}-{}", &self.to_string(), suffix);
-        let s_str = s.as_str();
+        let mut s = self.to_string();
+        s.push_str("-");
+        s.push_str(suffix);
 
-        match LogKey::from_str(s_str) {
+        match LogKey::from_str(&*s) {
             Ok(v) => v,
-            Err(_) => LogKey::from_str(&self.to_string()).unwrap(),
+            Err(_) => *self,
         }
     }
 }

--- a/src/lib/telemetry.rs
+++ b/src/lib/telemetry.rs
@@ -136,9 +136,7 @@ pub enum LogKey {
 
 impl LogKey {
     pub fn add_suffix(&self, suffix: &str) -> LogKey {
-        let mut s = self.to_string();
-        s.push('-');
-        s.push_str(suffix);
+        let s = self.to_string() + "-" + suffix;
 
         match LogKey::from_str(&s) {
             Ok(v) => v,

--- a/src/lib/telemetry.rs
+++ b/src/lib/telemetry.rs
@@ -137,7 +137,7 @@ pub enum LogKey {
 impl LogKey {
     pub fn add_suffix(&self, suffix: &str) -> LogKey {
         let mut s = self.to_string();
-        s.push_str("-");
+        s.push('-');
         s.push_str(suffix);
 
         match LogKey::from_str(&s) {

--- a/src/lib/telemetry.rs
+++ b/src/lib/telemetry.rs
@@ -140,7 +140,7 @@ impl LogKey {
         s.push_str("-");
         s.push_str(suffix);
 
-        match LogKey::from_str(&*s) {
+        match LogKey::from_str(&s) {
             Ok(v) => v,
             Err(_) => *self,
         }


### PR DESCRIPTION
Rewrite and simplify `add_suffix` to make it more efficient and "Rustic".

**But why?**

I was reading about how string allocation works in Rust and decided to try my hand at doing this "the right way" to check my understanding. No functionality is changed. I've annotated the code with PR comments to share learning.